### PR TITLE
[REQ-009, 010, 011] 냉장고 생성, 재료 사용, 재료 추가 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly("com.h2database:h2")
+    testImplementation("org.springframework.security:spring-security-test")
 }
 
 kotlin {

--- a/src/test/kotlin/com/example/home_recipe/controller/refrigerator/RefrigeratorControllerTest.kt
+++ b/src/test/kotlin/com/example/home_recipe/controller/refrigerator/RefrigeratorControllerTest.kt
@@ -1,0 +1,81 @@
+package com.example.home_recipe.controller.refrigerator
+
+import com.example.home_recipe.domain.ingredient.Ingredient
+import com.example.home_recipe.domain.ingredient.IngredientCategory
+import com.example.home_recipe.domain.user.User
+import com.example.home_recipe.repository.IngredientRepository
+import com.example.home_recipe.repository.RefrigeratorRepository
+import com.example.home_recipe.repository.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+class RefrigeratorControllerTest {
+
+    @Autowired lateinit var mockMvc: MockMvc
+    @Autowired lateinit var userRepository: UserRepository
+    @Autowired lateinit var ingredientRepository: IngredientRepository
+    @Autowired lateinit var refrigeratorRepository: RefrigeratorRepository
+
+    @Test
+    @DisplayName("POST /refrigerator - 냉장고 없으면 생성 후 201")
+    fun create_whenAbsent_created() {
+        // given
+        val email = "create1@example.com"
+        userRepository.save(User(email = email, password = "pw", name = "me"))
+
+        // when & then
+        mockMvc.perform(post("/refrigerator").with(user(email)))
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+
+        // then DB 확인
+        val u = userRepository.findByEmail(email).orElseThrow()
+        assertThat(u.hasRefrigerator()).isTrue()
+    }
+
+    @Test
+    @DisplayName("PUT /refrigerator/ingredient/{id} - 재료 추가")
+    fun addIngredient_success() {
+        val email = "add1@example.com"
+        userRepository.save(User(email = email, password = "pw", name = "me"))
+        mockMvc.perform(post("/refrigerator").with(user(email))).andExpect(status().isCreated)
+
+        val ing = ingredientRepository.save(Ingredient(IngredientCategory.VEGETABLE, "양파"))
+
+        mockMvc.perform(put("/refrigerator/ingredient/{id}", ing.id!!).with(user(email)))
+            .andExpect(status().isOk)
+
+        val u = userRepository.findByEmail(email).orElseThrow()
+        assertThat(u.refrigeratorExternal.ingredients.any { it.id == ing.id }).isTrue()
+    }
+
+    @Test
+    @DisplayName("DELETE /refrigerator/ingredient/{id} - 재료 사용")
+    fun useIngredient_success() {
+        val email = "use1@example.com"
+        userRepository.save(User(email = email, password = "pw", name = "me"))
+        mockMvc.perform(post("/refrigerator").with(user(email))).andExpect(status().isCreated)
+
+        val ing = ingredientRepository.save(Ingredient(IngredientCategory.VEGETABLE, "당근"))
+        mockMvc.perform(put("/refrigerator/ingredient/{id}", ing.id!!).with(user(email)))
+            .andExpect(status().isOk)
+
+        mockMvc.perform(delete("/refrigerator/ingredient/{id}", ing.id!!).with(user(email)))
+            .andExpect(status().isOk)
+
+        val u = userRepository.findByEmail(email).orElseThrow()
+        assertThat(u.refrigeratorExternal.ingredients.any { it.id == ing.id }).isFalse()
+    }
+}

--- a/src/test/kotlin/com/example/home_recipe/service/refrigerator/RefrigeratorEventJpaSliceTest.kt
+++ b/src/test/kotlin/com/example/home_recipe/service/refrigerator/RefrigeratorEventJpaSliceTest.kt
@@ -1,0 +1,89 @@
+package com.example.home_recipe.service.refrigerator
+
+import com.example.home_recipe.domain.ingredient.Ingredient
+import com.example.home_recipe.domain.refrigerator.Refrigerator
+import com.example.home_recipe.domain.user.User
+import com.example.home_recipe.repository.IngredientRepository
+import com.example.home_recipe.repository.RefreshTokenRepository
+import com.example.home_recipe.repository.RefrigeratorRepository
+import com.example.home_recipe.repository.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Import
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@Import(RefrigeratorService::class, TestEventInvoker::class, RefrigeratorEventJpaSliceTest.JpaTestConfig::class)
+class RefrigeratorEventJpaSliceTest {
+    @TestConfiguration
+    @EnableJpaRepositories(basePackageClasses = [
+        UserRepository::class,
+        RefrigeratorRepository::class,
+        IngredientRepository::class
+    ])
+    @EntityScan(basePackageClasses = [
+        User::class,
+        Refrigerator::class,
+        Ingredient::class
+    ])
+    class JpaTestConfig
+
+    @Autowired lateinit var userRepository: UserRepository
+    @Autowired lateinit var refrigeratorRepository: RefrigeratorRepository
+    @Autowired lateinit var invoker: TestEventInvoker
+
+    @Mock
+    lateinit var refreshTokenRepository: RefreshTokenRepository
+
+    @Test @DisplayName("UserJoinedEvent 처리로 냉장고 생성 및 할당")
+    fun userJoinedEvent_생성() {
+        val user = userRepository.save(User(email = "e@e.com", password = "pw", name = "name"))
+        invoker.publishUserJoinedAndCommit(user.id!!, user.email)
+        val reloaded = userRepository.findById(user.id!!).get()
+        assertThat(reloaded.hasRefrigerator()).isTrue()
+        val fridgeId = reloaded.refrigeratorExternal.id!!
+        assertThat(refrigeratorRepository.findById(fridgeId)).isPresent
+    }
+
+    @Test
+    @DisplayName("UserJoinedEvent - 이미 냉장고가 있으면 변경 없음(추가 생성 안 함)")
+    fun userJoinedEvent_이미있음() {
+        // given
+        val user = userRepository.save(User(email = "a@b.com", password = "pw", name = "me"))
+        val existing = refrigeratorRepository.save(Refrigerator.create())
+        user.assignRefrigerator(existing)
+        userRepository.save(user)
+
+        val before = refrigeratorRepository.count()
+
+        // when
+        invoker.publishUserJoinedAndCommit(user.id!!, user.email)
+
+        // then
+        val reloaded = userRepository.findById(user.id!!).get()
+        assertThat(reloaded.refrigeratorExternal.id).isEqualTo(existing.id)
+        assertThat(refrigeratorRepository.count()).isEqualTo(before) // 새로 안 만들어졌는지 확인
+    }
+
+    @Test
+    @DisplayName("UserJoinedEvent - 존재하지 않는 유저면 예외 발생")
+    fun userJoinedEvent_유저없음() {
+        // given
+        val notExists = 999_999L
+
+        // when & then
+        assertThatThrownBy {
+            invoker.publishUserJoinedAndCommit(notExists, "none@example.com")
+        }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/src/test/kotlin/com/example/home_recipe/service/refrigerator/RefrigeratorServiceTest.kt
+++ b/src/test/kotlin/com/example/home_recipe/service/refrigerator/RefrigeratorServiceTest.kt
@@ -1,0 +1,235 @@
+package com.example.home_recipe.service.refrigerator
+
+import com.example.home_recipe.domain.ingredient.Ingredient
+import com.example.home_recipe.domain.ingredient.IngredientCategory
+import com.example.home_recipe.domain.refrigerator.Refrigerator
+import com.example.home_recipe.domain.user.User
+import com.example.home_recipe.global.exception.BusinessException
+import com.example.home_recipe.global.response.code.IngredientCode
+import com.example.home_recipe.global.response.code.RefrigeratorCode
+import com.example.home_recipe.global.response.code.UserCode
+import com.example.home_recipe.repository.IngredientRepository
+import com.example.home_recipe.repository.RefrigeratorRepository
+import com.example.home_recipe.repository.UserRepository
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.Mockito.*
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+class RefrigeratorServiceTest {
+
+    @Mock
+    private lateinit var refrigeratorRepository: RefrigeratorRepository
+
+    @Mock
+    private lateinit var ingredientRepository: IngredientRepository
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @InjectMocks
+    private lateinit var refrigeratorService: RefrigeratorService
+
+    //////////////// 해피 테스트
+
+    @Test
+    @DisplayName("냉장고 생성 - 유저가 냉장고가 없으면 생성 후 할당")
+    fun 냉장고_생성_성공() {
+        // given
+        val email = "test@example.com"
+        val user = User(email = email, password = "encoded", name = "name")
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.of(user))
+
+        doAnswer { inv -> inv.getArgument<Refrigerator>(0) }
+            .whenever(refrigeratorRepository)
+            .save(any<Refrigerator>())
+
+        // when
+        val fridge = refrigeratorService.createForUser(email)
+
+        // then
+        Assertions.assertThat(user.hasRefrigerator()).isTrue()
+        Assertions.assertThat(fridge).isSameAs(user.refrigeratorExternal)
+        verify(refrigeratorRepository, times(1)).save(any<Refrigerator>())
+    }
+
+
+
+    @Test
+    @DisplayName("재료 추가 - 정상 추가 시 true")
+    fun 재료_추가_성공() {
+        // given
+        val email = "test@example.com"
+        val user = User(email = email, password = "encoded", name = "name")
+        val fridge = Refrigerator.create()
+        user.assignRefrigerator(fridge)
+
+        val ingredient = Ingredient(IngredientCategory.VEGETABLE, "양파").apply { id = 10L }
+
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.of(user))
+        whenever(ingredientRepository.findById(10L)).thenReturn(Optional.of(ingredient))
+
+        // when
+        val added = refrigeratorService.addIngredient(email, 10L)
+
+        // then
+        Assertions.assertThat(added).isTrue()
+        Assertions.assertThat(fridge.ingredients.any { it.id == 10L }).isTrue()
+        verify(ingredientRepository, times(1)).findById(10L)
+    }
+
+    @Test
+    @DisplayName("재료 사용 - 존재하면 제거되고 true")
+    fun 재료_사용_성공() {
+        // given
+        val email = "test@example.com"
+        val user = User(email = email, password = "encoded", name = "name")
+        val fridge = Refrigerator.create()
+        user.assignRefrigerator(fridge)
+
+        val ingredient = Ingredient(IngredientCategory.VEGETABLE, "양파").apply { id = 10L }
+        fridge.addIngredient(ingredient)
+
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.of(user))
+
+        // when
+        val removed = refrigeratorService.useIngredient(email, 10L)
+
+        // then
+        Assertions.assertThat(removed).isTrue()
+        Assertions.assertThat(fridge.ingredients.any { it.id == 10L }).isFalse()
+    }
+
+    //////////////// 예외/엣지 테스트
+
+    @Test
+    @DisplayName("냉장고 생성 - 이미 있으면 저장 호출 없이 기존 냉장고 반환")
+    fun 냉장고_이미있음() {
+        // given
+        val email = "test@example.com"
+        val user = User(email = email, password = "encoded", name = "name")
+        val existing = Refrigerator.create()
+        user.assignRefrigerator(existing)
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.of(user))
+
+        // when
+        val result = refrigeratorService.createForUser(email)
+
+        // then
+        Assertions.assertThat(result).isSameAs(existing)
+        verify(refrigeratorRepository, times(0)).save(any())
+    }
+
+    @Test
+    @DisplayName("재료 추가 - 이미 냉장고에 있으면 REFRIGERATOR_ERROR_005")
+    fun 재료_추가_중복_예외() {
+        // given
+        val email = "test@example.com"
+        val user = User(email = email, password = "encoded", name = "name")
+        val fridge = Refrigerator.create()
+        user.assignRefrigerator(fridge)
+        val ingredient = Ingredient(IngredientCategory.VEGETABLE, "양파").apply { id = 10L }
+        fridge.addIngredient(ingredient) // 이미 보유한 상태
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.of(user))
+        whenever(ingredientRepository.findById(10L)).thenReturn(Optional.of(ingredient)) // 같은 인스턴스 반환
+
+        // when & then
+        assertThatThrownBy {
+            refrigeratorService.addIngredient(email, 10L)
+        }
+            .isInstanceOf(BusinessException::class.java)
+            .hasMessageContaining(RefrigeratorCode.REFRIGERATOR_ERROR_005.message)
+    }
+
+    @Test
+    @DisplayName("재료 추가 - 재료가 없으면 INGREDIENT_ERROR_011")
+    fun 재료_추가_재료없음() {
+        // given
+        val email = "test@example.com"
+        val user = User(email = email, password = "encoded", name = "name")
+        val fridge = Refrigerator.create()
+        user.assignRefrigerator(fridge)
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.of(user))
+        whenever(ingredientRepository.findById(999L)).thenReturn(Optional.empty())
+
+        // when & then
+        assertThatThrownBy {
+            refrigeratorService.addIngredient(email, 999L)
+        }
+            .isInstanceOf(BusinessException::class.java)
+            .hasMessageContaining(IngredientCode.INGREDIENT_ERROR_011.message)
+    }
+
+    @Test
+    @DisplayName("재료 추가 - 냉장고가 없으면 REFRIGERATOR_ERROR_004")
+    fun 재료_추가_냉장고없음() {
+        // given
+        val email = "test@example.com"
+        val user = User(email = email, password = "encoded", name = "name") // 냉장고 미할당
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.of(user))
+
+        // when & then
+        assertThatThrownBy {
+            refrigeratorService.addIngredient(email, 1L)
+        }
+            .isInstanceOf(BusinessException::class.java)
+            .hasMessageContaining(RefrigeratorCode.REFRIGERATOR_ERROR_004.message)
+    }
+
+    @Test
+    @DisplayName("재료 사용 - 냉장고가 없으면 REFRIGERATOR_ERROR_004")
+    fun 재료_사용_냉장고없음() {
+        // given
+        val email = "test@example.com"
+        val user = User(email = email, password = "encoded", name = "name") // 냉장고 미할당
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.of(user))
+
+        // when & then
+        assertThatThrownBy {
+            refrigeratorService.useIngredient(email, 1L)
+        }
+            .isInstanceOf(BusinessException::class.java)
+            .hasMessageContaining(RefrigeratorCode.REFRIGERATOR_ERROR_004.message)
+    }
+
+    @Test
+    @DisplayName("재료 사용 - 없으면 false")
+    fun 재료_사용_없음_false() {
+        // given
+        val email = "test@example.com"
+        val user = User(email = email, password = "encoded", name = "name")
+        val fridge = Refrigerator.create()
+        user.assignRefrigerator(fridge)
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.of(user))
+
+        // when
+        val removed = refrigeratorService.useIngredient(email, 12345L)
+
+        // then
+        Assertions.assertThat(removed).isFalse()
+    }
+
+    @Test
+    @DisplayName("유저가 없으면 LOGIN_ERROR_002")
+    fun 유저없음_예외() {
+        // given
+        val email = "notfound@example.com"
+        whenever(userRepository.findByEmail(email)).thenReturn(Optional.empty())
+
+        // when & then
+        assertThatThrownBy {
+            refrigeratorService.createForUser(email)
+        }
+            .isInstanceOf(BusinessException::class.java)
+            .hasMessageContaining(UserCode.LOGIN_ERROR_002.message)
+    }
+}

--- a/src/test/kotlin/com/example/home_recipe/service/refrigerator/TestEventInvoker.kt
+++ b/src/test/kotlin/com/example/home_recipe/service/refrigerator/TestEventInvoker.kt
@@ -1,0 +1,22 @@
+package com.example.home_recipe.service.refrigerator
+
+import com.example.home_recipe.controller.dto.user.dto.UserJoinedEvent
+import jakarta.transaction.Transactional
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+@Service
+class TestEventInvoker(
+    private val publisher: ApplicationEventPublisher
+) {
+    @Transactional
+    fun publishUserJoinedAndCommit(userId: Long, email: String) {
+        // given
+        val event = UserJoinedEvent(userId = userId, email = email)
+
+        // when
+        publisher.publishEvent(event)
+
+        // then -> 커밋 시점에 리스너 동작 (BEFORE_COMMIT/AFTER_COMMIT 설정에 따라)
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,3 @@
+JWT_SECRET: test-secret
+jwt:
+  secret: test-secret


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #8 #9 #10

## #️⃣ 작업 내용

>
- 냉장고 엔티티 정의, 재료 엔티티 정의
- 냉장고 생성은 User 회원가입과 동시에 적용할 수 있도록 이벤트 기반으로 구현
- 냉장고에서의 User 참조 삭제 (단방향 연관관계, 냉장고 접근을 위해서는 반드시 user를 거치도록)
- 재료 관리는 Set으로 중복 불가하도록 구현

## #️⃣ 테스트 결과

> 단위테스트 전부 통과, 통합테스트 및 이벤트 기반 테스트 authController와 refreshTokenRepository Bean 주입 오류로 실패

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

<img width="1411" height="865" alt="image" src="https://github.com/user-attachments/assets/f340d5d0-f899-420c-a202-fda4f4510cac" />

## #️⃣ 리뷰 요구사항 (선택)

> 통합테스트 및 이벤트 기반 테스트 authController와 refreshTokenRepository Bean 주입 오류로 실패하는 문제가 있습니다.
해당 오류에 대해 따로 ISSUE 생성해서 해결해야할 것 같습니다, 원인이 뭔지 같이 찾아보면 좋을거 같아요..!

## 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요