### PR TITLE
refactor: MySQL 연결 설정 및 환경 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,6 @@ out/
 ###.env ###
 .env
 
-### test yml ###
+### yml ###
 application-test.yml
+application-local.yml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,13 +32,14 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 
+	implementation("com.mysql:mysql-connector-j")
+
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
-	testImplementation("com.h2database:h2")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,19 @@
+spring:
+  profiles:
+    default: local
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+    open-in-view: false
+
 jwt:
   secret: ${JWT_SECRET}
   access-expiration: ${JWT_ACCESS_EXPIRATION}

--- a/src/test/kotlin/com/example/home_recipe/repository/RefreshTokenRepositoryTest.kt
+++ b/src/test/kotlin/com/example/home_recipe/repository/RefreshTokenRepositoryTest.kt
@@ -6,9 +6,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.ActiveProfiles
 import kotlin.test.Test
 
 @DataJpaTest
+@ActiveProfiles("test")
 class RefreshTokenRepositoryTest {
     @Autowired
     private lateinit var tokenRepository: RefreshTokenRepository

--- a/src/test/kotlin/com/example/home_recipe/repository/UserRepositoryTest.kt
+++ b/src/test/kotlin/com/example/home_recipe/repository/UserRepositoryTest.kt
@@ -5,9 +5,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.ActiveProfiles
 import kotlin.test.Test
 
 @DataJpaTest
+@ActiveProfiles("test")
 class UserRepositoryTest {
     @Autowired
     private lateinit var userRepository: UserRepository


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 

## #️⃣ 작업 내용

> Front 화면 개발 과정에서 실제 데이터 저장 흐름을 확인하기 위해 MySQL을 연결했습니다.

MySQL 사용을 위해 환경 설정(application.yml, application-test.yml)을 수정
build.gradle에서 H2 관련 설정 제거 후 MySQL 의존성으로 교체
테스트 환경에서 test 스키마를 사용하도록 @DataJpaTest에 @ActiveProfiles("test") 적용

## #️⃣ 테스트 결과

> 모든 테스트 통과


## #️⃣ 스크린샷 (선택)


## #️⃣ 리뷰 요구사항 (선택)


## 참고 자료 (선택)
