### PR TITLE
AI 레시피 저장 기능 구현 PR

### DIFF
--- a/src/main/kotlin/com/example/home_recipe/domain/cache/GptCache.kt
+++ b/src/main/kotlin/com/example/home_recipe/domain/cache/GptCache.kt
@@ -1,0 +1,64 @@
+package com.example.home_recipe.domain.cache
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "gpt_cache",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_gpt_cache_key",
+            columnNames = [
+                "feature",
+                "model",
+                "prompt_version",
+                "ingredients_hash"
+            ]
+        )
+    ]
+)
+class GptCache(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(nullable = false, length = 32)
+    val feature: String,
+
+    @Column(nullable = false, length = 64)
+    val model: String,
+
+    @Column(name = "prompt_version", nullable = false)
+    val promptVersion: Int,
+
+    @Column(
+        name = "ingredients_hash",
+        nullable = false,
+        columnDefinition = "BINARY(32)"
+    )
+    val ingredientsHash: ByteArray,
+
+    @Column(
+        name = "normalized_ingredients_json",
+        nullable = false,
+        columnDefinition = "JSON"
+    )
+    val normalizedIngredientsJson: String,
+
+    @Column(
+        name = "response_json",
+        nullable = false,
+        columnDefinition = "JSON"
+    )
+    val responseJson: String,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "last_hit_at")
+    var lastHitAt: LocalDateTime? = null,
+
+    @Column(name = "hit_count", nullable = false)
+    var hitCount: Long = 0
+)

--- a/src/main/kotlin/com/example/home_recipe/repository/GptCacheRepository.kt
+++ b/src/main/kotlin/com/example/home_recipe/repository/GptCacheRepository.kt
@@ -1,0 +1,14 @@
+package com.example.home_recipe.repository
+
+import com.example.home_recipe.domain.cache.GptCache
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GptCacheRepository : JpaRepository<GptCache, Long> {
+
+    fun findByFeatureAndModelAndPromptVersionAndIngredientsHash(
+        feature: String,
+        model: String,
+        promptVersion: Int,
+        ingredientsHash: ByteArray
+    ): GptCache?
+}

--- a/src/main/kotlin/com/example/home_recipe/service/ingredient/IngredientKey.kt
+++ b/src/main/kotlin/com/example/home_recipe/service/ingredient/IngredientKey.kt
@@ -1,0 +1,25 @@
+package com.example.home_recipe.service.ingredient
+
+import java.security.MessageDigest
+
+object IngredientKey {
+
+    fun normalize(ingredients: List<String>): List<String> {
+        return ingredients.asSequence()
+            .map { it.trim().lowercase() }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .sorted()
+            .toList()
+    }
+
+    fun ingredientsHash(normalizedIngredients: List<String>): ByteArray {
+        val canonical = normalizedIngredients.joinToString("|")
+        return sha256(canonical)
+    }
+
+    private fun sha256(value: String): ByteArray {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(value.toByteArray(Charsets.UTF_8))
+    }
+}

--- a/src/main/kotlin/com/example/home_recipe/service/recipe/GptCacheService.kt
+++ b/src/main/kotlin/com/example/home_recipe/service/recipe/GptCacheService.kt
@@ -1,0 +1,75 @@
+package com.example.home_recipe.service.recipe
+
+import com.example.home_recipe.domain.cache.GptCache
+import com.example.home_recipe.repository.GptCacheRepository
+import com.example.home_recipe.service.ingredient.IngredientKey
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class GptCacheService(
+    private val gptCacheRepository: GptCacheRepository,
+    private val objectMapper: ObjectMapper
+) {
+
+    fun <T : Any> getOrCompute(
+        feature: String,
+        model: String,
+        promptVersion: Int,
+        ingredientsRaw: List<String>,
+        responseClass: Class<T>,
+        compute: () -> T
+    ): T {
+        val normalizedIngredients = IngredientKey.normalize(ingredientsRaw)
+        val ingredientsHash = IngredientKey.ingredientsHash(normalizedIngredients)
+
+        val cached = gptCacheRepository.findByFeatureAndModelAndPromptVersionAndIngredientsHash(
+            feature = feature,
+            model = model,
+            promptVersion = promptVersion,
+            ingredientsHash = ingredientsHash
+        )
+
+        if (cached != null) {
+            cached.lastHitAt = LocalDateTime.now()
+            cached.hitCount += 1
+            gptCacheRepository.save(cached)
+
+            return objectMapper.readValue(cached.responseJson, responseClass)
+        }
+
+        val freshResponse = compute()
+
+        val normalizedIngredientsJson = objectMapper.writeValueAsString(normalizedIngredients)
+        val responseJson = objectMapper.writeValueAsString(freshResponse)
+
+        try {
+            gptCacheRepository.save(
+                GptCache(
+                    feature = feature,
+                    model = model,
+                    promptVersion = promptVersion,
+                    ingredientsHash = ingredientsHash,
+                    normalizedIngredientsJson = normalizedIngredientsJson,
+                    responseJson = responseJson
+                )
+            )
+            return freshResponse
+        } catch (e: DataIntegrityViolationException) {
+            val saved = gptCacheRepository.findByFeatureAndModelAndPromptVersionAndIngredientsHash(
+                feature = feature,
+                model = model,
+                promptVersion = promptVersion,
+                ingredientsHash = ingredientsHash
+            ) ?: throw e
+
+            saved.lastHitAt = LocalDateTime.now()
+            saved.hitCount += 1
+            gptCacheRepository.save(saved)
+
+            return objectMapper.readValue(saved.responseJson, responseClass)
+        }
+    }
+}

--- a/src/main/kotlin/com/example/home_recipe/service/recipe/RecipePrompt.kt
+++ b/src/main/kotlin/com/example/home_recipe/service/recipe/RecipePrompt.kt
@@ -1,6 +1,7 @@
 package com.example.home_recipe.service.recipe
 
 object RecipePrompt {
+    const val VERSION = 1
 
     val SYSTEM_PROMPT = """
        너는 냉장고 상태를 보고 요리를 할지, 아니면 그냥 배달이나 시켜 먹을지 독설을 날리는 시니컬한 요리 AI다.

--- a/src/main/kotlin/com/example/home_recipe/service/recipe/RecipeService.kt
+++ b/src/main/kotlin/com/example/home_recipe/service/recipe/RecipeService.kt
@@ -5,7 +5,6 @@ import com.example.home_recipe.global.exception.BusinessException
 import com.example.home_recipe.global.response.code.RecipeCode
 import com.example.home_recipe.service.refrigerator.RefrigeratorService
 import com.openai.client.OpenAIClientAsync
-import com.openai.client.okhttp.OpenAIOkHttpClientAsync
 import com.openai.models.ChatModel
 import com.openai.models.chat.completions.ChatCompletionCreateParams
 import org.springframework.http.HttpStatus
@@ -14,28 +13,39 @@ import org.springframework.stereotype.Service
 @Service
 class RecipeService(
     private val openAiClient: OpenAIClientAsync,
-    val refrigeratorService: RefrigeratorService
+    private val refrigeratorService: RefrigeratorService,
+    private val gptCacheService: GptCacheService
 ) {
 
     fun chat(email: String): RecipesResponse {
-        val params = ChatCompletionCreateParams.builder()
-            .addSystemMessage(RecipePrompt.SYSTEM_PROMPT)
-            .addUserMessage(RecipePrompt.userPrompt(refrigeratorService.getMyIngredientsOnlyName(email)))
-            .model(ChatModel.GPT_5_MINI)
-            .responseFormat(RecipesResponse::class.java)
-            .build()
+        val ingredients = refrigeratorService.getMyIngredientsOnlyName(email)
 
-        val response = openAiClient.chat().completions().create(params).join()
+        return gptCacheService.getOrCompute(
+            feature = "RECIPE",
+            model = ChatModel.GPT_5_MINI.toString(),
+            promptVersion = RecipePrompt.VERSION,
+            ingredientsRaw = ingredients,
+            responseClass = RecipesResponse::class.java
+        ) {
+            val params = ChatCompletionCreateParams.builder()
+                .addSystemMessage(RecipePrompt.SYSTEM_PROMPT)
+                .addUserMessage(RecipePrompt.userPrompt(ingredients))
+                .model(ChatModel.GPT_5_MINI)
+                .responseFormat(RecipesResponse::class.java)
+                .build()
 
-        val contents = response.choices()
-            .firstOrNull()
-            ?.message()
-            ?.content()
+            val response = openAiClient.chat().completions().create(params).join()
 
-        if (contents == null) {
-            throw BusinessException(RecipeCode.RECIPE_ERROR_001, HttpStatus.INTERNAL_SERVER_ERROR)
+            val contents = response.choices()
+                .firstOrNull()
+                ?.message()
+                ?.content()
+
+            if (contents == null) {
+                throw BusinessException(RecipeCode.RECIPE_ERROR_001, HttpStatus.INTERNAL_SERVER_ERROR)
+            }
+
+            contents.get()
         }
-
-        return contents.get()
     }
 }


### PR DESCRIPTION
## 연관 이슈
- #59 

---

## 작업 내용

GPT API 비용을 줄이기 위해 GPT가 생성해주는 레시피를 저장하여
GPT 캐시 처럼 사용할 수 있도록 기능을 구현하였습니다.

---

## 구현 사항

### 1. GPT의 응답을 캐싱하도록 저장
- 도메인의 이름을 recipe으로 해서 저장할까 고민했지만, 목적에 맞게 GPT의 응답을 캐싱한다는 네이밍을 선정
- 저장하는 필드는
    - id
    - 생성일자
    - 특징 (레시피인지 추천인지)
    - 캐시 히트 수
    - 재료 해시값
    - 마지막 히트 일자 (넣을까 말까 고민하긴 했지만 일단 적용)
    - 레시피를 생성한 AI 모델
    - 정규화된 기본 재료 리스트
    - 응답값 (json)
    - 프롬프트 버전

으로 구성되어 있습니다.

### 2. 응답값을 그대로 저장한 이유
- 응답값이 긴 문자열임에도 해싱하지 않고 저장한 이유는 결국 사용자에게 return 해주어야 하는 응답값 자체이다 보니, 해싱과정과 파싱과정을 거칠바에야 그대로 저장하는 것이 더욱 이득이라 생각했습니다.

### 3. 버저닝
- 저장된 캐시값에 버전을 넣었고, AI 프롬프트에도 버전 필드를 추가했습니다.
- 추후에 캐시를 업데이트 해주어야 할 때 버전을 바꾸어 요청하면 DB를 거치지 않고 gpt API로 연결이 가능하며, 새로운 레시피 응답을 받아올 수 있습니다.

### 4. 현재 플로우
1. 사용자 레시피 추천 요청
2. DB에 해당 재료들로 만드는 레시피가 있는지 확인 (구현 부분)
2-2. DB에 있다면 DB에서 바로 응답
3. 없을 시 gpt API 조회
4. 가져온 결과값 DB에 저장

---

## 성능 비교

> 항상 gpt API 호출 할 때 (약 30초 소요)

<img width="916" height="912" alt="image" src="https://github.com/user-attachments/assets/c3044347-5d0b-4b7c-b1cb-0ee71768555d" />


> 캐싱 기능 구현 후 (62ms)
<img width="898" height="906" alt="image" src="https://github.com/user-attachments/assets/5fc29726-1cf7-4064-a250-882b7483a09b" />


---

## 리뷰 요청사항

- 이름이 비슷한 재료가 들어올 때 (예: 계란, 유정란, 무정란....) 이걸 하나로 통합시키는 기능이 필요할지
- 레시피 캐시를 업데이트하는 방식을 주기적으로 할 것인지 아니면 즉시즉시 할 것인지

---

## 참고 자료